### PR TITLE
remove dependency on string_methods

### DIFF
--- a/lib/netconf/device.rb
+++ b/lib/netconf/device.rb
@@ -6,7 +6,6 @@ require 'xml'
 require 'netconf/connection_exception'
 require 'netconf/rpc_error'
 require 'netconf/rpc_exception'
-require 'netconf/string_methods'
 
 module Netconf
   class Device


### PR DESCRIPTION
Still raises an error because the missing string_methods
